### PR TITLE
new feature: add queue support

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>openai-java</artifactId>
-        <version>0.23.19</version>
+        <version>0.23.21</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>openai-api</artifactId>

--- a/api/src/main/java/com/theokanning/openai/queue/Put.java
+++ b/api/src/main/java/com/theokanning/openai/queue/Put.java
@@ -1,0 +1,67 @@
+package com.theokanning.openai.queue;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * Represents a queue put operation for task queuing
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Put {
+    /**
+     * The endpoint URL for the queue operation
+     */
+    private String endpoint;
+
+    /**
+     * The name of the queue
+     */
+    private String queue;
+
+    /**
+     * The priority level of the task in the queue (default: 0)
+     */
+    @Builder.Default
+    private Integer level = 0;
+
+    /**
+     * The data payload to be processed
+     */
+    private Map<String, Object> data;
+
+    /**
+     * The response mode for the operation (default: "callback") Supported modes: "callback", "blocking", "streaming"
+     */
+    @Builder.Default
+    private String responseMode = "callback";
+
+    /**
+     * The callback URL for asynchronous responses
+     */
+    @JsonProperty("callback_url")
+    private String callbackUrl;
+
+    /**
+     * The timeout duration for the operation in seconds
+     */
+    private int timeout;
+
+    /**
+     * Returns the full queue name by combining the queue name and level
+     *
+     * @return formatted queue name as "queueName:level"
+     */
+    @JsonIgnore
+    public String getFullQueueName() {
+        return String.format("%s:%d", queue, level);
+    }
+}

--- a/api/src/main/java/com/theokanning/openai/queue/Register.java
+++ b/api/src/main/java/com/theokanning/openai/queue/Register.java
@@ -1,0 +1,25 @@
+package com.theokanning.openai.queue;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a queue registration request to register an endpoint with a specific queue
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Register {
+    /**
+     * The name of the queue to register with
+     */
+    private String queue;
+    
+    /**
+     * The endpoint to register for queue operations
+     */
+    private String endpoint;
+}

--- a/api/src/main/java/com/theokanning/openai/queue/Take.java
+++ b/api/src/main/java/com/theokanning/openai/queue/Take.java
@@ -1,0 +1,38 @@
+package com.theokanning.openai.queue;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Represents a queue take operation to retrieve tasks from one or more queues
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Take {
+    /**
+     * The endpoint URL for the take operation
+     */
+    private String endpoint;
+
+    /**
+     * List of queue names to take tasks from
+     */
+    private List<String> queues;
+
+    /**
+     * Maximum number of tasks to retrieve
+     */
+    private Integer size;
+
+    /**
+     * The strategy for taking tasks from queues (default: "fifo") Supported strategies: "fifo", "round_robin", "active_passive"
+     */
+    @Builder.Default
+    private String strategy = "fifo";
+}

--- a/api/src/main/java/com/theokanning/openai/queue/Task.java
+++ b/api/src/main/java/com/theokanning/openai/queue/Task.java
@@ -1,0 +1,116 @@
+package com.theokanning.openai.queue;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * Represents a task in the queue system with execution details and status information
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Task {
+    /**
+     * Unique identifier for the task
+     */
+    @JsonProperty("task_id")
+    private String taskId;
+
+    /**
+     * Access key for authentication
+     */
+    private String ak;
+
+    /**
+     * The endpoint where the task will be executed
+     */
+    private String endpoint;
+
+    /**
+     * The name of the queue containing this task
+     */
+    private String queue;
+
+    /**
+     * The priority level of the task in the queue
+     */
+    private Integer level;
+
+    /**
+     * The data payload for the task
+     */
+    private Map<String, Object> data;
+
+    /**
+     * Current status of the task (e.g., "pending", "running", "succeeded", "failed", "cancelled")
+     */
+    private String status;
+
+    /**
+     * The result of the task execution
+     */
+    private Object result;
+
+    /**
+     * Identifier of the instance executing this task
+     */
+    @JsonProperty("instance_id")
+    private String instanceId;
+
+    /**
+     * Timestamp when the task started execution
+     */
+    @JsonProperty("start_time")
+    private long startTime;
+
+    /**
+     * Duration the task has been running in milliseconds
+     */
+    @JsonProperty("running_time")
+    private long runningTime;
+
+    /**
+     * Timestamp when the task completed execution
+     */
+    @JsonProperty("completed_time")
+    private long completedTime;
+
+    /**
+     * URL to call back with task results
+     */
+    @JsonProperty("callback_url")
+    private String callbackUrl;
+
+    /**
+     * Mode for delivering task responses
+     */
+    @JsonProperty("response_mode")
+    private String responseMode;
+
+    /**
+     * Returns the full queue name by combining the queue name and level
+     *
+     * @return formatted queue name as "queueName:level"
+     */
+    @JsonIgnore
+    public String getFullQueueName() {
+        return String.format("%s:%d", queue, level);
+    }
+
+    /**
+     * Checks if the task has finished execution (succeeded, failed, or cancelled)
+     *
+     * @return true if the task is in a finished state
+     */
+    @JsonIgnore
+    public boolean isFinish() {
+        return "succeeded".equals(status) || "failed".equals(status) || "cancelled".equals(status);
+    }
+}

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>openai-java</artifactId>
-        <version>0.23.19</version>
+        <version>0.23.21</version>
     </parent>
     <packaging>jar</packaging>
 

--- a/client/src/main/java/com/theokanning/openai/client/OpenAiApi.java
+++ b/client/src/main/java/com/theokanning/openai/client/OpenAiApi.java
@@ -42,6 +42,10 @@ import com.theokanning.openai.image.ImageResult;
 import com.theokanning.openai.model.Model;
 import com.theokanning.openai.moderation.ModerationRequest;
 import com.theokanning.openai.moderation.ModerationResult;
+import com.theokanning.openai.queue.Register;
+import com.theokanning.openai.queue.Put;
+import com.theokanning.openai.queue.Take;
+import com.theokanning.openai.queue.Task;
 import io.reactivex.Single;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
@@ -50,6 +54,7 @@ import retrofit2.Call;
 import retrofit2.http.*;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 
 public interface OpenAiApi {
@@ -368,6 +373,22 @@ public interface OpenAiApi {
 
     @GET("batches")
     Single<OpenAiResponse<Batch>> listBatches(@QueryMap Map<String, Object> filterRequest);
+
+    // Queue operations
+    @POST("v1/queue/register")
+    Single<String> registerQueue(@Body Register register);
+
+    @POST("v1/queue/put")
+    Single<Object> putTask(@Body Put put);
+
+    @POST("v1/queue/take")
+    Single<Map<String, List<Task>>> takeTasks(@Body Take take);
+
+    @POST("v1/queue/{task_id}/cancel")
+    Single<String> cancelTask(@Path("task_id") String taskId);
+
+    @POST("v1/queue/{task_id}/complete")
+    Single<String> completeTask(@Path("task_id") String taskId, @Body Map<String, Object> data);
 
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>top.bella</groupId>
     <artifactId>openai-java</artifactId>
-    <version>0.23.19</version>
+    <version>0.23.21</version>
     <packaging>pom</packaging>
     <description>openai java 版本</description>
     <name>openai-java</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>openai-java</artifactId>
-        <version>0.23.19</version>
+        <version>0.23.21</version>
     </parent>
     <packaging>jar</packaging>
 

--- a/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
+++ b/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
@@ -51,6 +51,10 @@ import com.theokanning.openai.image.ImageResult;
 import com.theokanning.openai.model.Model;
 import com.theokanning.openai.moderation.ModerationRequest;
 import com.theokanning.openai.moderation.ModerationResult;
+import com.theokanning.openai.queue.Put;
+import com.theokanning.openai.queue.Register;
+import com.theokanning.openai.queue.Take;
+import com.theokanning.openai.queue.Task;
 import com.theokanning.openai.service.assistant_stream.AssistantResponseBodyCallback;
 import com.theokanning.openai.service.assistant_stream.AssistantSSE;
 import io.reactivex.BackpressureStrategy;
@@ -743,6 +747,27 @@ public class OpenAiService {
 
     public Batch cancelBatch(String batchId) {
         return execute(api.cancelBatch(batchId));
+    }
+
+    // Queue operations
+    public String registerQueue(Register register) {
+        return execute(api.registerQueue(register));
+    }
+
+    public Object putTask(Put put) {
+        return execute(api.putTask(put));
+    }
+
+    public Map<String, List<Task>> takeTasks(Take take) {
+        return execute(api.takeTasks(take));
+    }
+
+    public String cancelTask(String taskId) {
+        return execute(api.cancelTask(taskId));
+    }
+
+    public String completeTask(String taskId, Map<String, Object> data) {
+        return execute(api.completeTask(taskId, data));
     }
 
     public static OpenAiApi buildApi(String token, Duration timeout, String baseUrl) {

--- a/service/src/test/java/com/theokanning/openai/service/QueueTest.java
+++ b/service/src/test/java/com/theokanning/openai/service/QueueTest.java
@@ -1,0 +1,93 @@
+package com.theokanning.openai.service;
+
+import com.theokanning.openai.queue.Put;
+import com.theokanning.openai.queue.Register;
+import com.theokanning.openai.queue.Take;
+import com.theokanning.openai.queue.Task;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Queue operation tests Note: These tests are disabled as they require a custom queue service backend that implements the /v1/queue/* endpoints,
+ * which are not part of the standard OpenAI API
+ */
+@Disabled("Queue endpoints require custom backend service")
+public class QueueTest {
+
+    com.theokanning.openai.service.OpenAiService service = new OpenAiService();
+
+    @Test
+    void registerQueue() {
+        Register register = Register.builder()
+                .queue("test-queue")
+                .endpoint("http://localhost:8080/webhook")
+                .build();
+
+        String result = service.registerQueue(register);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void putTask() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("message", "test message");
+        data.put("priority", 1);
+
+        Put put = Put.builder()
+                .endpoint("http://localhost:8080/webhook")
+                .queue("test-queue")
+                .level(0)
+                .data(data)
+                .responseMode("callback")
+                .callbackUrl("http://localhost:8080/callback")
+                .timeout(60)
+                .build();
+
+        Object result = service.putTask(put);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void takeTasks() {
+        Take take = Take.builder()
+                .endpoint("http://localhost:8080/webhook")
+                .queues(Arrays.asList("test-queue-1", "test-queue-2"))
+                .size(10)
+                .strategy("fifo")
+                .build();
+
+        Map<String, List<Task>> result = service.takeTasks(take);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void cancelTask() {
+        String taskId = "test-task-id-123";
+
+        String result = service.cancelTask(taskId);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void completeTask() {
+        String taskId = "test-task-id-123";
+        Map<String, Object> data = new HashMap<>();
+        data.put("result", "success");
+        data.put("output", "Task completed successfully");
+
+        String result = service.completeTask(taskId, data);
+
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
  Added queue management methods to OpenAiService:
  - registerQueue(Register register)
  - putTask(Put put)
  - takeTasks(Take take)
  - cancelTask(String taskId)
  - completeTask(String taskId, Map<String, Object> data)