### PR TITLE
Update README dependency coordinates

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,4 +1,4 @@
-![Maven Central](https://img.shields.io/maven-central/v/io.github.lambdua/service?color=blue)
+![Maven Central](https://img.shields.io/maven-central/v/top.bella/openai-service?color=blue)
 
 # OpenAi4J
 
@@ -21,14 +21,14 @@ OpenAi4J是一个非官方的Java库，旨在帮助java开发者与OpenAI的GPT�
 ## 导入依赖
 ### Gradle
 
-`implementation 'io.github.lambdua:<api|client|service>:0.22.92'`
+`implementation 'top.bella:<openai-api|openai-client|openai-service>:<version>'`
 ### Maven
 ```xml
 
 <dependency>
-    <groupId>io.github.lambdua</groupId>
-    <artifactId>service</artifactId>
-    <version>0.22.92</version>
+    <groupId>top.bella</groupId>
+    <artifactId>openai-service</artifactId>
+    <version>${latest.version}</version>
 </dependency>
 ```
 
@@ -59,9 +59,9 @@ static void simpleChat() {
 ```xml
 
 <dependency>
-    <groupId>io.github.lambdua</groupId>
-    <artifactId>api</artifactId>
-    <version>0.22.92</version>
+    <groupId>top.bella</groupId>
+    <artifactId>openai-api</artifactId>
+    <version>${latest.version}</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Maven Central](https://img.shields.io/maven-central/v/io.github.lambdua/service?color=blue)
+![Maven Central](https://img.shields.io/maven-central/v/top.bella/openai-service?color=blue)
 
 # OpenAi4J
 
@@ -25,14 +25,14 @@ applications effortlessly.
 ## Import
 ### Gradle
 
-`implementation 'io.github.lambdua:<api|client|service>:0.22.92'`
+`implementation 'top.bella:<openai-api|openai-client|openai-service>:<version>'`
 ### Maven
 ```xml
 
 <dependency>
-  <groupId>io.github.lambdua</groupId>
-  <artifactId>service</artifactId>
-    <version>0.22.92</version>
+  <groupId>top.bella</groupId>
+  <artifactId>openai-service</artifactId>
+  <version>${latest.version}</version>
 </dependency>
 ```
 
@@ -65,9 +65,9 @@ To utilize pojos, import the api module:
 ```xml
 
 <dependency>
-  <groupId>io.github.lambdua</groupId>
-  <artifactId>api</artifactId>
-    <version>0.22.92</version>
+  <groupId>top.bella</groupId>
+  <artifactId>openai-api</artifactId>
+  <version>${latest.version}</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary
- update README dependency coordinates to use the new `top.bella` groupId and module artifactIds
- switch version numbers in README snippets to placeholders to reflect configurable versions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d362e591508327982b0a60d69add25